### PR TITLE
Exclude on atomic repo

### DIFF
--- a/manifests/repo/atomic.pp
+++ b/manifests/repo/atomic.pp
@@ -10,5 +10,6 @@ class yum::repo::atomic {
     gpgcheck   => 1,
     gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY.art',
     priority   => 1,
+    exclude    => 'nmap-ncat',
   }
 }


### PR DESCRIPTION
ART uses nmap-netcat which breaks some scripts which depend on -d flag. Set to exclude.
