### PR TITLE
It is necessary to manually replace $releasever with either "5" (for 5.x...

### DIFF
--- a/manifests/repo/nginx.pp
+++ b/manifests/repo/nginx.pp
@@ -3,10 +3,11 @@
 # This class installs the nginx repo
 #
 class yum::repo::nginx {
+  $osver = split($::operatingsystemrelease, '[.]')
 
   yum::managed_yumrepo { 'nginx':
     descr => 'Nginx official release packages',
-    baseurl => 'http://nginx.org/packages/rhel/$releasever/$basearch/',
+    baseurl => 'http://nginx.org/packages/rhel/${osver[0]}/$basearch/',
     enabled => 1,
     gpgcheck => 0,
     priority => 1,


### PR DESCRIPTION
...) or "6" (for 6.x)

http://wiki.nginx.org/Install

'Due to differences between how CentOS, RHEL, and Scientific Linux populate the $releasever variable, it is necessary to manually replace $releasever with either "5" (for 5.x) or "6" (for 6.x), depending upon your OS version.'
