### PR TITLE
Add support for OracleLinux

### DIFF
--- a/manifests/repo/epel.pp
+++ b/manifests/repo/epel.pp
@@ -7,8 +7,8 @@ class yum::repo::epel {
   $osver = split($::operatingsystemrelease, '[.]')
 
   yum::managed_yumrepo { 'epel':
-    descr          => 'Extra Packages for Enterprise Linux $releasever - $basearch',
-    mirrorlist     => 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-$releasever&arch=$basearch',
+    descr          => "Extra Packages for Enterprise Linux ${osver[0]} - \$basearch",
+    mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${osver[0]}&arch=\$basearch",
     enabled        => 1,
     gpgcheck       => 1,
     failovermethod => 'priority',
@@ -18,8 +18,8 @@ class yum::repo::epel {
   }
 
   yum::managed_yumrepo { 'epel-debuginfo':
-    descr          => 'Extra Packages for Enterprise Linux $releasever - $basearch - Debug',
-    mirrorlist     => 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-$releasever&arch=$basearch',
+    descr          => "Extra Packages for Enterprise Linux ${osver[0]} - \$basearch - Debug",
+    mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
     failovermethod => 'priority',
@@ -28,8 +28,8 @@ class yum::repo::epel {
   }
 
   yum::managed_yumrepo { 'epel-source':
-    descr          => 'Extra Packages for Enterprise Linux $releasever - $basearch - Source',
-    mirrorlist     => 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-$releasever&arch=$basearch',
+    descr          => "Extra Packages for Enterprise Linux ${osver[0]} - \$basearch - Source",
+    mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
     failovermethod => 'priority',
@@ -38,8 +38,8 @@ class yum::repo::epel {
   }
 
   yum::managed_yumrepo { 'epel-testing':
-    descr          => 'Extra Packages for Enterprise Linux $releasever - Testing - $basearch',
-    mirrorlist     => 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel5&arch=$basearch',
+    descr          => "Extra Packages for Enterprise Linux ${osver[0]} - Testing - \$basearch",
+    mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
     failovermethod => 'priority',
@@ -48,8 +48,8 @@ class yum::repo::epel {
   }
 
   yum::managed_yumrepo { 'epel-testing-debuginfo':
-    descr          => 'Extra Packages for Enterprise Linux $releasever - Testing - $basearch - Debug',
-    mirrorlist     => 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel5&arch=$basearch',
+    descr          => "Extra Packages for Enterprise Linux ${osver[0]} - Testing - \$basearch - Debug",
+    mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
     failovermethod => 'priority',
@@ -58,8 +58,8 @@ class yum::repo::epel {
   }
 
   yum::managed_yumrepo { 'epel-testing-source':
-    descr          => 'Extra Packages for Enterprise Linux $releasever - Testing - $basearch - Source',
-    mirrorlist     => 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel5&arch=$basearch',
+    descr          => "Extra Packages for Enterprise Linux ${osver[0]} - Testing - \$basearch - Source",
+    mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
     failovermethod => priority,


### PR DESCRIPTION
Epel needs the version Number 6. But OracleLinux provides 6Server as $releasever
