### PR TITLE
Update rpmforge repo URL, and also a $releasever workaround

### DIFF
--- a/manifests/repo/rpmforge.pp
+++ b/manifests/repo/rpmforge.pp
@@ -3,15 +3,26 @@
 # This class installs the rpmforce repo
 #
 class yum::repo::rpmforge {
-
-  yum::managed_yumrepo { 'rpmforge-rhel5':
-    descr          => 'RPMForge RHEL5 packages',
-    baseurl        => 'http://wftp.tu-chemnitz.de/pub/linux/dag/redhat/el$releasever/en/$basearch/dag',
-    enabled        => 1,
-    gpgcheck       => 1,
-    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',
+  case $::operatingsystemmajrelease {
+    '6': {
+      $baseurl = 'http://apt.sw.be/redhat/el6/en/$basearch/rpmforge'
+      $mirrorlist = 'http://apt.sw.be/redhat/el6/en/mirrors-rpmforge'
+    }
+    '5': {
+      $baseurl = 'http://apt.sw.be/redhat/el5/en/$basearch/rpmforge'
+      $mirrorlist = 'http://apt.sw.be/redhat/el5/en/mirrors-rpmforge'
+    }
+    default: { fail("Unsupported version of Enterprise Linux") }
+  }
+  yum::managed_yumrepo { 'rpmforge':
+    baseurl  => $baseurl,
+    mirrorlist => $mirrorlist,
+    descr    => 'RHEL $releasever - RPMforge.net - dag',
+    enabled  => 1,
+    gpgcheck => 1,
+    gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',
     gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',
-    priority       => 30,
+    priority => 30,
   }
 
 }


### PR DESCRIPTION
2 things:
# /1 the rpmforge repo was giving me 404 errors and when I checked out the official site, it said to use `apt.sw.be`. After modifying the file with these changes, no more 404. So I was happy.
# /2  it appears the yum variable `$releasever` evaluates to "6Server" which wouldn't work unless the people managing the repo symlinked `6Server -> 6`.  There's plenty of evidence on google of people having the same problem. A workaround is to not use `$releasever`, and use a case statement for the fact `$operatingsystemmajrelease` instead.

Let me know what you think!
