### PR TITLE
Add $mirror_url parameter to a few common repos

### DIFF
--- a/manifests/repo/centos5.pp
+++ b/manifests/repo/centos5.pp
@@ -2,11 +2,64 @@
 #
 # Base Centos5 repos
 #
-class yum::repo::centos5 {
+# == Parameters:
+#
+# [*mirror_url*]
+#   A clean URL to a mirror of `rsync://msync.centos.org::CentOS`.
+#   The paramater is interpolated with the known directory structure to
+#   create a the final baseurl parameter for each yumrepo so it must be
+#   "clean", i.e., without a query string like `?key1=valA&key2=valB`.
+#   Additionally, it may not contain a trailing slash.
+#   Example: `http://mirror.example.com/pub/rpm/centos`
+#   Default: `undef`
+#
+class yum::repo::centos5 (
+  $mirror_url = undef,
+) {
+
+  if $mirror_url {
+    validate_re(
+      $mirror_url,
+      '^(?:https?|ftp):\/\/[\da-zA-Z-][\da-zA-Z\.-]*\.[a-zA-Z]{2,6}\.?(?:\/[\w~-]*)*$',
+      '$mirror must be a Clean URL with no query-string, a fully-qualified hostname and no trailing slash.'
+    )
+  }
+
+  $baseurl_base = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/os/\$basearch/",
+  }
+
+  $baseurl_updates = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/updates/\$basearch/",
+  }
+
+  $baseurl_addons = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/addons/\$basearch/",
+  }
+
+  $baseurl_extras = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/extras/\$basearch/",
+  }
+
+  $baseurl_centosplus = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/centosplus/\$basearch/",
+  }
+
+  $baseurl_contrib = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/contrib/\$basearch/",
+  }
 
   yum::managed_yumrepo { 'base':
     descr          => 'CentOS-$releasever - Base',
+    baseurl        => $baseurl_base,
     mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os',
+    failovermethod => 'priority',
     enabled        => 1,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
@@ -15,47 +68,57 @@ class yum::repo::centos5 {
   }
 
   yum::managed_yumrepo { 'updates':
-    descr      => 'CentOS-$releasever - Updates',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
-    priority   => 1,
+    descr          => 'CentOS-$releasever - Updates',
+    baseurl        => $baseurl_updates,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
+    priority       => 1,
   }
 
   yum::managed_yumrepo { 'addons':
-    descr      => 'CentOS-$releasever - Addons',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=addons',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
-    priority   => 1,
+    descr          => 'CentOS-$releasever - Addons',
+    baseurl        => $baseurl_addons,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=addons',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
+    priority       => 1,
   }
 
   yum::managed_yumrepo { 'extras':
-    descr      => 'CentOS-$releasever - Extras',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
-    priority   => 1,
+    descr          => 'CentOS-$releasever - Extras',
+    baseurl        => $baseurl_extras,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
+    priority       => 1,
   }
 
   yum::managed_yumrepo { 'centosplus':
-    descr      => 'CentOS-$releasever - Centosplus',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
-    priority   => 2,
+    descr          => 'CentOS-$releasever - Centosplus',
+    baseurl        => $baseurl_centosplus,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
+    priority       => 2,
   }
 
   yum::managed_yumrepo { 'contrib':
-    descr      => 'CentOS-$releasever - Contrib',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib',
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
-    priority   => 10,
+    descr          => 'CentOS-$releasever - Contrib',
+    baseurl        => $baseurl_contrib,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib',
+    failovermethod => 'priority',
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
+    priority       => 10,
   }
 
 }

--- a/manifests/repo/centos6.pp
+++ b/manifests/repo/centos6.pp
@@ -2,11 +2,59 @@
 #
 # Base Centos6 repos
 #
-class yum::repo::centos6 {
+# == Parameters:
+#
+# [*mirror_url*]
+#   A clean URL to a mirror of `rsync://msync.centos.org::CentOS`.
+#   The paramater is interpolated with the known directory structure to
+#   create a the final baseurl parameter for each yumrepo so it must be
+#   "clean", i.e., without a query string like `?key1=valA&key2=valB`.
+#   Additionally, it may not contain a trailing slash.
+#   Example: `http://mirror.example.com/pub/rpm/centos`
+#   Default: `undef`
+#
+class yum::repo::centos6 (
+  $mirror_url = undef,
+) {
+
+  if $mirror_url {
+    validate_re(
+      $mirror_url,
+      '^(?:https?|ftp):\/\/[\da-zA-Z-][\da-zA-Z\.-]*\.[a-zA-Z]{2,6}\.?(?:\/[\w~-]*)*$',
+      '$mirror must be a Clean URL with no query-string, a fully-qualified hostname and no trailing slash.'
+    )
+  }
+
+  $baseurl_base = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/os/\$basearch/",
+  }
+
+  $baseurl_updates = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/updates/\$basearch/",
+  }
+
+  $baseurl_extras = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/extras/\$basearch/",
+  }
+
+  $baseurl_centosplus = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/centosplus/\$basearch/",
+  }
+
+  $baseurl_contrib = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/\$releasever/contrib/\$basearch/",
+  }
 
   yum::managed_yumrepo { 'base':
     descr          => 'CentOS-$releasever - Base',
+    baseurl        => $baseurl_base,
     mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os',
+    failovermethod => 'priority',
     enabled        => 1,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
@@ -15,38 +63,46 @@ class yum::repo::centos6 {
   }
 
   yum::managed_yumrepo { 'updates':
-    descr      => 'CentOS-$releasever - Updates',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
-    priority   => 1,
+    descr          => 'CentOS-$releasever - Updates',
+    baseurl        => $baseurl_updates,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
+    priority       => 1,
   }
 
   yum::managed_yumrepo { 'extras':
-    descr      => 'CentOS-$releasever - Extras',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
-    priority   => 1,
+    descr          => 'CentOS-$releasever - Extras',
+    baseurl        => $baseurl_extras,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
+    priority       => 1,
   }
 
   yum::managed_yumrepo { 'centosplus':
-    descr      => 'CentOS-$releasever - Centosplus',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
-    priority   => 2,
+    descr          => 'CentOS-$releasever - Centosplus',
+    baseurl        => $baseurl_centosplus,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
+    priority       => 2,
   }
 
   yum::managed_yumrepo { 'contrib':
-    descr      => 'CentOS-$releasever - Contrib',
-    mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib',
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
-    priority   => 10,
+    descr          => 'CentOS-$releasever - Contrib',
+    baseurl        => $baseurl_contrib,
+    mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib',
+    failovermethod => 'priority',
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
+    priority       => 10,
   }
 
 }

--- a/manifests/repo/epel.pp
+++ b/manifests/repo/epel.pp
@@ -2,7 +2,28 @@
 #
 # This class installs the epel repo
 #
-class yum::repo::epel {
+# == Parameters:
+#
+# [*mirror_url*]
+#   A clean URL to a mirror of `http://dl.fedoraproject.org/pub/epel/`.
+#   The paramater is interpolated with the known directory structure to
+#   create a the final baseurl parameter for each yumrepo so it must be
+#   "clean", i.e., without a query string like `?key1=valA&key2=valB`.
+#   Additionally, it may not contain a trailing slash.
+#   Example: `http://mirror.example.com/pub/rpm/epel`
+#   Default: `undef`
+#
+class yum::repo::epel (
+  $mirror_url = undef,
+) {
+
+  if $mirror_url {
+    validate_re(
+      $mirror_url,
+      '^(?:https?|ftp):\/\/[\da-zA-Z-][\da-zA-Z\.-]*\.[a-zA-Z]{2,6}\.?(?:\/[\w~-]*)*$',
+      '$mirror must be a Clean URL with no query-string, a fully-qualified hostname and no trailing slash.'
+    )
+  }
 
   if $::operatingsystem == 'Amazon' {
     $osver = [ '6' ]
@@ -10,8 +31,39 @@ class yum::repo::epel {
     $osver = split($::operatingsystemrelease, '[.]')
   }
 
+  $baseurl_epel = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/${osver[0]}/\$basearch/",
+  }
+
+  $baseurl_epel_debuginfo = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/${osver[0]}/\$basearch/debug",
+  }
+
+  $baseurl_epel_source = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/${osver[0]}/SRPMS/",
+  }
+
+  $baseurl_epel_testing = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/testing/${osver[0]}/\$basearch/",
+  }
+
+  $baseurl_epel_testing_debuginfo = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/testing/${osver[0]}/\$basearch/debug",
+  }
+
+  $baseurl_epel_testing_source = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/testing/${osver[0]}/SRPMS/",
+  }
+
   yum::managed_yumrepo { 'epel':
     descr          => "Extra Packages for Enterprise Linux ${osver[0]} - \$basearch",
+    baseurl        => $baseurl_epel,
     mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${osver[0]}&arch=\$basearch",
     enabled        => 1,
     gpgcheck       => 1,
@@ -23,6 +75,7 @@ class yum::repo::epel {
 
   yum::managed_yumrepo { 'epel-debuginfo':
     descr          => "Extra Packages for Enterprise Linux ${osver[0]} - \$basearch - Debug",
+    baseurl        => $baseurl_epel_debuginfo,
     mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
@@ -33,6 +86,7 @@ class yum::repo::epel {
 
   yum::managed_yumrepo { 'epel-source':
     descr          => "Extra Packages for Enterprise Linux ${osver[0]} - \$basearch - Source",
+    baseurl        => $baseurl_epel_source,
     mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
@@ -43,6 +97,7 @@ class yum::repo::epel {
 
   yum::managed_yumrepo { 'epel-testing':
     descr          => "Extra Packages for Enterprise Linux ${osver[0]} - Testing - \$basearch",
+    baseurl        => $baseurl_epel_testing,
     mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
@@ -53,6 +108,7 @@ class yum::repo::epel {
 
   yum::managed_yumrepo { 'epel-testing-debuginfo':
     descr          => "Extra Packages for Enterprise Linux ${osver[0]} - Testing - \$basearch - Debug",
+    baseurl        => $baseurl_epel_testing_debuginfo,
     mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
@@ -63,10 +119,11 @@ class yum::repo::epel {
 
   yum::managed_yumrepo { 'epel-testing-source':
     descr          => "Extra Packages for Enterprise Linux ${osver[0]} - Testing - \$basearch - Source",
+    baseurl        => $baseurl_epel_testing_source,
     mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel${osver[0]}&arch=\$basearch",
     enabled        => 0,
     gpgcheck       => 1,
-    failovermethod => priority,
+    failovermethod => 'priority',
     gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${osver[0]}",
     priority       => 17,
   }

--- a/manifests/repo/sl.pp
+++ b/manifests/repo/sl.pp
@@ -2,11 +2,49 @@
 #
 # Base Scientific Linux repos
 #
-class yum::repo::sl {
+# == Parameters:
+#
+# [*mirror_url*]
+#   A clean URL to a mirror of `http://ftp.scientificlinux.org/linux/scientific/`.
+#   The paramater is interpolated with the known directory structure to
+#   create a the final baseurl parameter for each yumrepo so it must be
+#   "clean", i.e., without a query string like `?key1=valA&key2=valB`.
+#   Additionally, it may not contain a trailing slash.
+#   Example: `http://mirror.example.com/pub/rpm/scientific`
+#   Default: `undef`
+#
+class yum::repo::sl (
+  $mirror_url = undef,
+) {
+
+  if $mirror_url {
+    validate_re(
+      $mirror_url,
+      '^(?:https?|ftp):\/\/[\da-zA-Z-][\da-zA-Z\.-]*\.[a-zA-Z]{2,6}\.?(?:\/[\w~-]*)*$',
+      '$mirror must be a Clean URL with no query-string, a fully-qualified hostname and no trailing slash.'
+    )
+  }
+
+  $baseurl_sl6x = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/6x/\$basearch/os/",
+  }
+
+  $baseurl_sl6x_security = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/6x/\$basearch/updates/security/",
+  }
+
+  $baseurl_sl6x_fastbugs = $mirror_url ? {
+    undef   => undef,
+    default => "${mirror_url}/6x/\$basearch/updates/fastbugs/",
+  }
 
   yum::managed_yumrepo { 'sl6x':
     descr          => 'Scientific Linux 6x - $basearch',
+    baseurl        => $baseurl_sl6x,
     mirrorlist     => 'http://ftp.scientificlinux.org/linux/scientific/mirrorlist/sl-base-6x.txt',
+    failovermethod => 'priority',
     enabled        => 1,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
@@ -14,19 +52,23 @@ class yum::repo::sl {
   }
 
   yum::managed_yumrepo { 'sl6x-security':
-    descr      => 'Scientific Linux 6x - $basearch - security updates',
-    mirrorlist => 'http://ftp.scientificlinux.org/linux/scientific/mirrorlist/sl-security-6x.txt',
-    enabled    => 1,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
+    descr          => 'Scientific Linux 6x - $basearch - security updates',
+    baseurl        => $baseurl_sl6x_security,
+    mirrorlist     => 'http://ftp.scientificlinux.org/linux/scientific/mirrorlist/sl-security-6x.txt',
+    failovermethod => 'priority',
+    enabled        => 1,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
   }
 
   yum::managed_yumrepo { 'sl6x-fastbugs':
-    descr      => 'Scientific Linux 6x - $basearch - fastbug updates',
-    mirrorlist => 'http://ftp.scientificlinux.org/linux/scientific/mirrorlist/sl-fastbugs-6x.txt',
-    enabled    => 0,
-    gpgcheck   => 1,
-    gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
+    descr          => 'Scientific Linux 6x - $basearch - fastbug updates',
+    baseurl        => $baseurl_sl6x_fastbugs,
+    mirrorlist     => 'http://ftp.scientificlinux.org/linux/scientific/mirrorlist/sl-fastbugs-6x.txt',
+    failovermethod => 'priority',
+    enabled        => 0,
+    gpgcheck       => 1,
+    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
   }
 
 }


### PR DESCRIPTION
This adds the parameter $mirror_url to the repo classes for CentOS 6, CentOS 5, Scientific Linx and EPEL.  It's intended to allow the use of local mirrors through Puppet 3.x databinding.

The parameter takes a "clean" URL to the base of the mirroring infrastructure for each class, e.g., http://msync.centos.org/centos for CentOS.  After checking it against a regex for clean URLs with stdlib's validatere(), it interpolates with the known directory structure to create `basedir` variables for each repo.  The `failovermethod` parameter is set to `priority` for each repo to avoid round-robin behavior with the existing `mirrorlist`.
