### PR TITLE
Add upstream default priorities for SL5 official repos.

### DIFF
--- a/manifests/repo/sl5.pp
+++ b/manifests/repo/sl5.pp
@@ -49,6 +49,7 @@ class yum::repo::sl5 (
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
     gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-sl',
+    priority       => 10,
   }
 
   yum::managed_yumrepo { 'sl5x-security':
@@ -59,6 +60,7 @@ class yum::repo::sl5 (
     enabled        => 1,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
+    priority       => 10,
   }
 
   yum::managed_yumrepo { 'sl5x-fastbugs':
@@ -69,6 +71,7 @@ class yum::repo::sl5 (
     enabled        => 0,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
+    priority       => 10,
   }
 
 }


### PR DESCRIPTION
Add upstream priorities to SL5 repo definitions (prevent problems whith priroties from puppetlabs repo installed using extrarepo parameter.).
(cf: ftp://ftp.scientificlinux.org/linux/scientific/5x/i386/SL/yum-conf-5x-2-1.sl5.noarch.rpm)
