### PR TITLE
Changed mirrorlist url for atomic repositories

### DIFF
--- a/manifests/repo/atomic.pp
+++ b/manifests/repo/atomic.pp
@@ -5,7 +5,7 @@
 class yum::repo::atomic {
   yum::managed_yumrepo { 'atomic':
     descr          => 'CentOS / Red Hat Enterprise Linux $releasever - atomicrocketturtle.com',
-    mirrorlist     => 'http://www.atomicorp.com/mirrorlist/atomic/centos-$releasever-$basearch',
+    mirrorlist     => 'http://www.atomicorp.com/channels/mirrorlist/atomic/centos-$releasever-$basearch',
     enabled        => 1,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY.art',


### PR DESCRIPTION
Looks like Atomic have changed the address of the mirrorlist
