### PR TITLE
Newrelic doesn't seem to maintain repos for seperate Enterprise Linux re...

### DIFF
--- a/manifests/repo/newrelic.pp
+++ b/manifests/repo/newrelic.pp
@@ -6,7 +6,7 @@ class yum::repo::newrelic {
 
   yum::managed_yumrepo { 'newrelic':
     descr     => 'Newrelic official release packages',
-    baseurl   => 'http://yum.newrelic.com/pub/newrelic/$releasever/$basearch/',
+    baseurl   => 'http://yum.newrelic.com/pub/newrelic/el5/$basearch/',
     enabled   => 1,
     gpgcheck  => 0,
     priority  => 1,


### PR DESCRIPTION
...leases. All rpms are held under http://yum.newrelic.com/pub/newrelic/el5/.
