### PR TITLE
Fixed error in pki-file-source for puppet*-repositories

### DIFF
--- a/manifests/repo/puppetdevel.pp
+++ b/manifests/repo/puppetdevel.pp
@@ -14,7 +14,7 @@ class yum::repo::puppetdevel (
     gpgcheck       => 1,
     failovermethod => 'priority',
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-PGDG',
+    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-puppetlabs',
     priority       => 15,
   }
 

--- a/manifests/repo/puppetlabs.pp
+++ b/manifests/repo/puppetlabs.pp
@@ -29,7 +29,7 @@ class yum::repo::puppetlabs (
     gpgcheck       => 1,
     failovermethod => 'priority',
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-PGDG',
+    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-puppetlabs',
     priority       => 1,
   }
 
@@ -44,7 +44,7 @@ class yum::repo::puppetlabs (
     gpgcheck       => 1,
     failovermethod => 'priority',
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-PGDG',
+    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-puppetlabs',
     priority       => 1,
   }
 


### PR DESCRIPTION
Hi,

there is a minor problem in the repo-definitions for the puppet-repos. This has been fixed. Please pull if you like.

Regards
Andreas
