### PR TITLE
Added CloudLinux support

### DIFF
--- a/manifests/repo/puppetlabs.pp
+++ b/manifests/repo/puppetlabs.pp
@@ -8,7 +8,7 @@ class yum::repo::puppetlabs (
 ) {
   $osver = split($::operatingsystemrelease, '[.]')
   $release = $::operatingsystem ? {
-    /(?i:Centos|RedHat|Scientific)/ => $osver[0],
+    /(?i:Centos|RedHat|Scientific|CloudLinux)/ => $osver[0],
     default                         => '6',
   }
 


### PR DESCRIPTION
Added support for CloudLinux. Without this fix el6 reposities will be installed on CloudLinux5.
