### PR TITLE
yum-updatesd: switch configuration to a template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -189,6 +189,9 @@ class yum (
   $cron_param          = params_lookup( 'cron_param' ),
   $cron_mailto         = params_lookup( 'cron_mailto' ),
   $cron_dotw           = params_lookup( 'cron_dotw' ),
+  $updatesd_emit_via   = params_lookup( 'updatesd_emit_via' ),
+  $updatesd_email_from = params_lookup( 'updatesd_email_from' ),
+  $updatesd_email_to   = params_lookup( 'updatesd_email_to' ),
   $log_file            = params_lookup( 'log_file' ),
   $priorities_plugin   = params_lookup( 'priorities_plugin' )
   ) inherits yum::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,6 +62,12 @@ class yum::params  {
   $cron_emit_via = 'stdio'
   $cron_email_host = 'localhost'
 
+  # The following params are for updatesd.pp
+
+  $updatesd_emit_via = 'dbus'
+  $updatesd_email_to = ''
+  $updatesd_email_from = ''
+
   $source = ''
   $source_dir = ''
   $source_dir_purge = false

--- a/manifests/updatesd.pp
+++ b/manifests/updatesd.pp
@@ -43,7 +43,7 @@ class yum::updatesd {
   file { 'yum-updatesd.conf':
     ensure  => $manage_update_file,
     path    => '/etc/yum/yum-updatesd.conf',
-    source  => 'puppet:///modules/yum/yum-updatesd.conf',
+    content => template('yum/yum-updatesd.erb'),
     require => Package['yum-updatesd'],
   }
 

--- a/templates/yum-updatesd.erb
+++ b/templates/yum-updatesd.erb
@@ -1,3 +1,9 @@
+<% emit_via = scope.lookupvar('yum::updatesd_emit_via')
+   email_to = scope.lookupvar('yum::updatesd_email_to')
+   email_from = scope.lookupvar('yum::updatesd_email_from')
+
+   email_from = "yum-updatesd@#{fqdn}" if email_from.empty?
+-%>
 # File Managed by Puppet
 [main]
 # how often to check for new updates (in seconds)
@@ -6,9 +12,14 @@ run_interval = 3600
 updaterefresh = 600
 
 # how to send notifications (valid: dbus, email, syslog)
-emit_via = dbus
+emit_via = <%= emit_via %>
+<% if emit_via == 'email' -%>
+# email settings
+email_from = <%= email_from %>
+email_to = <%= email_to %>
+<% end -%>
 # should we listen via dbus to give out update information/check for
-# new updates 
+# new updates
 dbus_listener = yes
 
 # automatically install updates
@@ -17,4 +28,3 @@ do_update = yes
 do_download = no
 # automatically download deps of updates
 do_download_deps = no
-


### PR DESCRIPTION
This allows the emit method to be configurable. There are a couple
possibilities, but this change only adds "email" and "dbus".