### PR TITLE
Fixes Travis CI checks with Ruby 1.8.7 and lower

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -4,4 +4,4 @@ puppetversion = ENV['PUPPET_VERSION']
 gem 'puppet', puppetversion, :require => false
 gem 'puppet-lint'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'rspec-puppet', '0.1.6'
+gem 'rspec-puppet', '>= 0.1.6'


### PR DESCRIPTION
Travis CI is currently broken with 1.8.7 and lower. This appears to fix it on my local instance.
