### PR TITLE
Change fixture URLs to use HTTPS

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,10 @@
 fixtures:
   repositories:
-    "puppi": "git://github.com/example42/puppi.git"
-    "monitor": "git://github.com/example42/puppet-monitor.git"
-    "firewall": "git://github.com/example42/puppet-firewall.git"
-    "iptables": "git://github.com/example42/puppet-iptables.git"
-    "concat": "git://github.com/example42/puppet-concat.git"
+    "puppi": "https://github.com/example42/puppi.git"
+    "monitor": "https://github.com/example42/puppet-monitor.git"
+    "firewall": "https://github.com/example42/puppet-firewall.git"
+    "iptables": "https://github.com/example42/puppet-iptables.git"
+    "concat": "https://github.com/example42/puppet-concat.git"
   symlinks:
     "yum": "#{source_dir}"
 


### PR DESCRIPTION
GitHub recommends URLs be specified to use HTTPS (and for some reason git:// always shows ECONNREFUSED from my machine anyway).
