### PR TITLE
added missing param plugins_source_dir

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,8 @@ class yum::params  {
 
   $clean_repos = false
 
+  $plugins_source_dir = undef
+  
   $plugins_config_dir = '/etc/yum/pluginconf.d'
 
   $source_repo_dir = undef


### PR DESCRIPTION
This gets looked for via param_lookup but never found. it is tripping my own unittesting.

Great work, much appreciated!