### PR TITLE
Add CLEANDAY option for yum-cron on centos6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,6 +195,7 @@ class yum (
   $cron_param           = params_lookup( 'cron_param' ),
   $cron_mailto          = params_lookup( 'cron_mailto' ),
   $cron_dotw            = params_lookup( 'cron_dotw' ),
+  $cron_clean_dotw      = params_lookup( 'cron_clean_dotw' ),
   $cron_update_cmd      = params_lookup( 'cron_update_cmd' ),
   $cron_update_messages = params_lookup( 'cron_update_messages' ),
   $cron_apply_updates   = params_lookup( 'cron_apply_updates' ),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,6 +62,7 @@ class yum::params  {
 
   $cron_param = ''
   $cron_dotw = '0123456'
+  $cron_clean_dotw = '0'
 
   # The following params are for cron.pp only for version 7
 

--- a/templates/yum-cron.erb
+++ b/templates/yum-cron.erb
@@ -52,7 +52,8 @@ DAYS_OF_WEEK=<%= scope.lookupvar('yum::cron_dotw') %>
 
 # which day should it do cleanup on?  defaults to 0 (Sunday).  If this day isn't in the 
 # DAYS_OF_WEEK above, it'll never happen
-CLEANDAY="0"
+#CLEANDAY="0"
+CLEANDAY="<%= scope.lookupvar('yum::cron_clean_dotw') %>"
 
 # set to yes to make the yum-cron service to wait for transactions to complete
 SERVICE_WAITS=yes


### PR DESCRIPTION
As the config file mention:
If this day isn't in the DAYS_OF_WEEK above, it'll never happen

