### PR TITLE
Openshift server

### DIFF
--- a/manifests/repo/openshift-server.pp
+++ b/manifests/repo/openshift-server.pp
@@ -1,11 +1,16 @@
 # = Class: yum::repo::openshift-server
 #
 # This class installs the openshift-server repo for CentOS6
+# Used for puppet-openshift_origin (https://github.com/openshift/puppet-openshift_origin)
+# when setting 'install_method' to 'none' in addition with 'yum::repo::epel' and 'yum::repo::jenkins' 
 #
-class yum::repo::openshift-server ($version=4)
+class yum::repo::openshift-server ($version=4) {
+  if $lsbdistrelease !~ /^6/ {
+    warning('This module works only for RHEL6')
+  }
   yum::managed_yumrepo { 'openshift-origin':
     descr          => 'Openshift Origin',
-    baseurl        => 'https://mirror.openshift.com/pub/origin-server/release/$version/rhel-6/packages/${::architecture}',
+    baseurl        => "https://mirror.openshift.com/pub/origin-server/release/${version}/rhel-6/packages/${::architecture}",
     enabled        => 1,
     gpgcheck       => 0,
     failovermethod => 'priority',
@@ -16,7 +21,7 @@ class yum::repo::openshift-server ($version=4)
 
   yum::managed_yumrepo { 'openshift-deps':
     descr          => 'Openshift Dependencies',
-    baseurl        => 'https://mirror.openshift.com/pub/origin-server/release/4/rhel-6/dependencies/x86_64/',
+    baseurl        => "https://mirror.openshift.com/pub/origin-server/release/${version}/rhel-6/dependencies/${::architecture}",
     enabled        => 1,
     gpgcheck       => 0,
     failovermethod => 'priority',

--- a/manifests/repo/openshift-server.pp
+++ b/manifests/repo/openshift-server.pp
@@ -1,0 +1,27 @@
+# = Class: yum::repo::openshift-server
+#
+# This class installs the openshift-server repo for CentOS6
+#
+class yum::repo::openshift-server ($version=4)
+  yum::managed_yumrepo { 'openshift-origin':
+    descr          => 'Openshift Origin',
+    baseurl        => 'https://mirror.openshift.com/pub/origin-server/release/$version/rhel-6/packages/${::architecture}',
+    enabled        => 1,
+    gpgcheck       => 0,
+    failovermethod => 'priority',
+    priority       => 1,
+    mirrorlist     => absent,
+    require        => Package['yum-plugin-priorities'],
+  }
+
+  yum::managed_yumrepo { 'openshift-deps':
+    descr          => 'Openshift Dependencies',
+    baseurl        => 'https://mirror.openshift.com/pub/origin-server/release/4/rhel-6/dependencies/x86_64/',
+    enabled        => 1,
+    gpgcheck       => 0,
+    failovermethod => 'priority',
+    priority       => 1,
+    mirrorlist     => absent,
+    require        => Package['yum-plugin-priorities'],
+  }
+}


### PR DESCRIPTION
Added a class to have dependencies used by https://github.com/openshift/puppet-openshift_origin with 'install_method' set to 'none'. To use with 'yum::repo::epel' and 'yum::repo::jenkins' for basic installation