### PR TITLE
updated url foreman repo

### DIFF
--- a/manifests/repo/foreman.pp
+++ b/manifests/repo/foreman.pp
@@ -3,17 +3,19 @@
 # This class installs the foreman repo
 #
 class yum::repo::foreman (
-  $baseurl_main = 'http://yum.theforeman.org/stable/',
+  $baseurl_main = "http://yum.theforeman.org/releases/latest/el${::operatingsystemmajrelease}/${::hardwaremodel}/",
   $baseurl_plugins  = undef,
 ) {
-
+  if $::operatingsystemmajrelease < 6 {
+    warning('The Foreman repo is only available for RHEL >= 6')
+  }
   yum::managed_yumrepo { 'foreman':
     descr          => 'Foreman Repo',
     baseurl        => $baseurl_main,
     enabled        => 1,
     gpgcheck       => 1,
     failovermethod => 'priority',
-    gpgkey         => 'http://yum.theforeman.org/RPM-GPG-KEY-foreman',
+    gpgkey         => 'http://yum.theforeman.org/releases/latest/RPM-GPG-KEY-foreman',
     priority       => 1,
   }
 


### PR DESCRIPTION
The url http://yum.theforeman.org/stable/ doesn't work anymore

Just changed it to the latest release