### PR TITLE
sl6: add priority 2 for official repositories.

### DIFF
--- a/manifests/repo/sl6.pp
+++ b/manifests/repo/sl6.pp
@@ -49,6 +49,7 @@ class yum::repo::sl6 (
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
     gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-sl',
+    priority       => 2,
   }
 
   yum::managed_yumrepo { 'sl6x-security':
@@ -59,6 +60,7 @@ class yum::repo::sl6 (
     enabled        => 1,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
+    priority       => 2,
   }
 
   yum::managed_yumrepo { 'sl6x-fastbugs':
@@ -69,6 +71,7 @@ class yum::repo::sl6 (
     enabled        => 0,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dawson',
+    priority       => 2,
   }
 
 }


### PR DESCRIPTION
Add priority 2 (like for CentOS 6) to default SL6 repositories.