### PR TITLE
Fix for error: No matching entry for selector parameter with value '7'

### DIFF
--- a/manifests/repo/pgdg94.pp
+++ b/manifests/repo/pgdg94.pp
@@ -5,13 +5,13 @@
 class yum::repo::pgdg94 {
 
   yum::managed_yumrepo { 'pgdg94':
-    descr          => 'PostgreSQL 9.4 $releasever - $basearch',
-    baseurl        => 'http://yum.postgresql.org/9.4/redhat/rhel-$releasever-$basearch',
-    enabled        => 1,
-    gpgcheck       => 1,
-    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG',
-    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-PGDG',
-    priority       => 20,
+    descr         => 'PostgreSQL 9.4 $releasever - $basearch',
+    baseurl       => 'http://yum.postgresql.org/9.4/redhat/rhel-$releasever-$basearch',
+    enabled       => 1,
+    gpgcheck      => 1,
+    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG',
+    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-PGDG',
+    priority      => 20,
   }
 
 }

--- a/manifests/repo/pgdg95.pp
+++ b/manifests/repo/pgdg95.pp
@@ -5,13 +5,13 @@
 class yum::repo::pgdg95 {
 
   yum::managed_yumrepo { 'pgdg95':
-    descr          => 'PostgreSQL 9.5 $releasever - $basearch',
-    baseurl        => 'http://yum.postgresql.org/9.5/redhat/rhel-$releasever-$basearch',
-    enabled        => 1,
-    gpgcheck       => 1,
-    gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG',
-    gpgkey_source  => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-PGDG',
-    priority       => 20,
+    descr         => 'PostgreSQL 9.5 $releasever - $basearch',
+    baseurl       => 'http://yum.postgresql.org/9.5/redhat/rhel-$releasever-$basearch',
+    enabled       => 1,
+    gpgcheck      => 1,
+    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG',
+    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-PGDG',
+    priority      => 20,
   }
 
 }

--- a/manifests/repo/webtatic.pp
+++ b/manifests/repo/webtatic.pp
@@ -4,7 +4,7 @@
 #
 class yum::repo::webtatic {
   $osver = split($::operatingsystemrelease, '[.]')
-  $mirrorlist = $osver[0] ? {
+  $mirrorlist = (0+$osver[0]) ? {
     5 => 'http://repo.webtatic.com/yum/centos/5/$basearch/mirrorlist',
     6 => 'http://repo.webtatic.com/yum/el6/$basearch/mirrorlist',
     7 => 'http://repo.webtatic.com/yum/el7/$basearch/mirrorlist',

--- a/manifests/repo/webtatic.pp
+++ b/manifests/repo/webtatic.pp
@@ -9,11 +9,11 @@ class yum::repo::webtatic {
     6 => 'http://repo.webtatic.com/yum/el6/$basearch/mirrorlist',
     7 => 'http://repo.webtatic.com/yum/el7/$basearch/mirrorlist',
   }
-  $gpgkey = $osver[0] ? {
+  $gpgkey = (0+$osver[0]) ? {
     7       => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-webtatic-el7',
     default => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-webtatic-andy',
   }
-  $gpgkey_source = $osver[0] ? {
+  $gpgkey_source = (0+$osver[0]) ? {
     7       => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-webtatic-el7',
     default => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-webtatic-andy',
   }


### PR DESCRIPTION
I had following error:

```
==> default: Debug: importing '/tmp/vagrant-puppet/modules-1d4682507a6d4aac498d84685726f3b6/yum/manifests/managed_yumrepo.pp' in environment development
==> default: Debug: Automatically imported yum::managed_yumrepo from yum/managed_yumrepo into development
==> default: Debug: importing '/tmp/vagrant-puppet/modules-1d4682507a6d4aac498d84685726f3b6/yum/manifests/repo/webtatic.pp' in environment development
==> default: Debug: Automatically imported yum::repo::webtatic from yum/repo/webtatic into development
==> default: Error: Evaluation Error: No matching entry for selector parameter with value '7' at /tmp/vagrant-puppet/modules-1d4682507a6d4aac498d84685726f3b6/yum/manifests/repo/webtatic.pp:7:19 on node vagrant.lpp.local
```

Probably reason was wrong variable type, my PR fixes this.

Using under vagrant box: puppetlabs/centos-7.0-64-puppet
