### PR TITLE
yum: fix for param_lookup returning empty string for undef value.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,17 +280,22 @@ class yum (
     default    => false,
   }
 
+  # XXX param_lookup returns '' instead of undef
+  $real_source_repo_dir = $yum::source_repo_dir ? {
+   ''      => undef,
+   default => $yum::source_repo_dir,
+  }
   file { 'yum.repo_dir':
     ensure  => directory,
     path    => $yum::repo_dir,
-    source  => $yum::source_repo_dir,
+    source  => $real_source_repo_dir,
     recurse => true,
     purge   => $yum::bool_clean_repos,
     replace => $yum::manage_file_replace,
     audit   => $yum::manage_audit,
   }
 
-  if $yum::source_repo_dir == undef {
+  if $real_source_repo_dir == undef {
     include yum::defaults
   }
 


### PR DESCRIPTION
As param_lookup returns '' instead of undef it breaks with future_parser ('' is not a correct value for the source parameter of a File resource). It is a quick and dirty fix but it simple and seems to work. At least it is a starting point.