### PR TITLE
centosplus unenabled

### DIFF
--- a/manifests/repo/centos6.pp
+++ b/manifests/repo/centos6.pp
@@ -89,7 +89,6 @@ class yum::repo::centos6 (
     baseurl        => $baseurl_centosplus,
     mirrorlist     => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus',
     failovermethod => 'priority',
-    enabled        => 1,
     gpgcheck       => 1,
     gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6',
     priority       => 3,


### PR DESCRIPTION
Centosplus repo is not enabled by default in centos 6