### PR TITLE
Update/fix remi repos

### DIFF
--- a/manifests/repo/remi.pp
+++ b/manifests/repo/remi.pp
@@ -12,14 +12,4 @@ class yum::repo::remi {
     gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-remi',
     priority      => 1,
   }
-
-  yum::managed_yumrepo { 'remi-test':
-    descr         => 'Les RPM de remi pour Enterpise Linux $releasever - $basearch - Test',
-    mirrorlist    => 'http://rpms.famillecollet.com/enterprise/$releasever/test/mirror',
-    enabled       => 0,
-    gpgcheck      => 1,
-    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
-    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-remi',
-    priority      => 1,
-  }
 }

--- a/manifests/repo/remi.pp
+++ b/manifests/repo/remi.pp
@@ -4,12 +4,11 @@
 #
 class yum::repo::remi {
   yum::managed_yumrepo { 'remi':
-    descr         => 'Les RPM de remi pour Enterpise Linux $releasever - $basearch',
-    mirrorlist    => 'http://rpms.famillecollet.com/enterprise/$releasever/remi/mirror',
-    enabled       => 1,
-    gpgcheck      => 1,
-    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
-    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-remi',
-    priority      => 1,
+    descr      => 'Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/remi/mirror',
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1
   }
 }

--- a/manifests/repo/remi_php55.pp
+++ b/manifests/repo/remi_php55.pp
@@ -4,12 +4,11 @@
 #
 class yum::repo::remi_php55 {
   yum::managed_yumrepo { 'remi-php55':
-    descr         => 'Les RPM de remi pour Enterpise Linux $releasever - $basearch - PHP 5.5',
-    mirrorlist    => 'http://rpms.famillecollet.com/enterprise/$releasever/php55/mirror',
-    enabled       => 1,
-    gpgcheck      => 1,
-    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
-    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-remi',
-    priority      => 1,
+    descr      => 'Remi\'s PHP 5.5 RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/php55/mirror',
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1
   }
 }

--- a/manifests/repo/remi_php56.pp
+++ b/manifests/repo/remi_php56.pp
@@ -4,12 +4,11 @@
 #
 class yum::repo::remi_php56 {
   yum::managed_yumrepo { 'remi-php56':
-    descr         => 'Les RPM de remi pour Enterpise Linux $releasever - $basearch - PHP 5.6',
-    mirrorlist    => 'http://rpms.famillecollet.com/enterprise/$releasever/php56/mirror',
-    enabled       => 1,
-    gpgcheck      => 1,
-    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
-    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-remi',
-    priority      => 1,
+    descr      => 'Remi\'s PHP 5.6 RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/php56/mirror',
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1
   }
 }

--- a/manifests/repo/remi_php70.pp
+++ b/manifests/repo/remi_php70.pp
@@ -4,21 +4,19 @@
 #
 class yum::repo::remi_php70 {
   yum::managed_yumrepo { 'remi-php70':
-    descr         => 'Remi\'s PHP 7.0 RPM repository for Enterprise Linux 7 - $basearch',
-    mirrorlist    => 'http://rpms.remirepo.net/enterprise/7/php70/mirror',
-    enabled       => 1,
-    gpgcheck      => 1,
-    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
-    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-remi',
-    priority      => 1,
+    descr      => 'Remi\'s PHP 7.0 RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/php70/mirror',
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1
   }
 
   yum::managed_yumrepo { 'remi-php70-debuginfo':
-    descr         => 'Remi\'s PHP 7.0 RPM repository for Enterprise Linux 7 - $basearch - debuginfo',
-    baseurl       => 'http://rpms.remirepo.net/enterprise/7/debug-php70/$basearch/',
-    enabled       => 0,
-    gpgcheck      => 1,
-    gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
-    gpgkey_source => 'puppet:///modules/yum/rpm-gpg/RPM-GPG-KEY-remi',
+    descr      => 'Remi\'s PHP 7.0 RPM repository for Enterprise Linux $releasever - $basearch - debuginfo',
+    baseurl    => 'http://rpms.remirepo.net/enterprise/$releasever/debug-php70/$basearch/',
+    enabled    => 0,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
   }
 }

--- a/manifests/repo/remi_safe.pp
+++ b/manifests/repo/remi_safe.pp
@@ -1,0 +1,14 @@
+# = Class: yum::repo::remi_safe
+#
+# This class installs the remi safe repo
+#
+class yum::repo::remi_safe {
+  yum::managed_yumrepo { 'remi-safe':
+    descr      => 'Safe Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/safe/mirror',
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1
+  }
+}

--- a/manifests/repo/remi_test.pp
+++ b/manifests/repo/remi_test.pp
@@ -1,0 +1,14 @@
+# = Class: yum::repo::remi_test
+#
+# This class installs the remi test repo
+#
+class yum::repo::remi_test {
+  yum::managed_yumrepo { 'remi-test':
+    descr      => 'Remi\'s test RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/test/mirror',
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1
+  }
+}


### PR DESCRIPTION
Couple of fixes/addition:

* Added were missing the `remi-safe` repo
* Moved `remi-test` repo to it's own class
* Updated repo descriptions and ensured all repo configs use `$releasever` (`php70` had 7 hardcoded it's mirrorlist resulting in broken repo on centos 6)