### PR TITLE
repo not listed in official remi.repo

### DIFF
--- a/manifests/repo/remi_php70.pp
+++ b/manifests/repo/remi_php70.pp
@@ -11,12 +11,4 @@ class yum::repo::remi_php70 {
     gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
     priority   => 1
   }
-
-  yum::managed_yumrepo { 'remi-php70-debuginfo':
-    descr      => 'Remi\'s PHP 7.0 RPM repository for Enterprise Linux $releasever - $basearch - debuginfo',
-    baseurl    => 'http://rpms.remirepo.net/enterprise/$releasever/debug-php70/$basearch/',
-    enabled    => 0,
-    gpgcheck   => 1,
-    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
-  }
 }


### PR DESCRIPTION
While fixing the lint warnings I found the repo isn't listed in http://rpms.remirepo.net/enterprise/remi.repo so have removed it.  
