### PR TITLE
Issue #158 - Don't use yum's $releasever on Amazon linux

### DIFF
--- a/manifests/repo/elastix.pp
+++ b/manifests/repo/elastix.pp
@@ -51,5 +51,5 @@ class yum::repo::elastix {
     enabled  => 1,
     gpgcheck => 0,
   }
-  
+
 }

--- a/manifests/repo/remi.pp
+++ b/manifests/repo/remi.pp
@@ -3,9 +3,14 @@
 # This class installs the remi repo
 #
 class yum::repo::remi {
+  $releasever = $::os['name'] ? {
+    /(?i:Amazon)/ => '6',
+    default       => '$releasever',  # Yum var
+  }
+
   yum::managed_yumrepo { 'remi':
     descr      => 'Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/remi/mirror',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/remi/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',

--- a/manifests/repo/remi_php55.pp
+++ b/manifests/repo/remi_php55.pp
@@ -3,9 +3,14 @@
 # This class installs the remi-php55 repo
 #
 class yum::repo::remi_php55 {
+  $releasever = $::os['name'] ? {
+    /(?i:Amazon)/ => '6',
+    default       => '$releasever',  # Yum var
+  }
+
   yum::managed_yumrepo { 'remi-php55':
     descr      => 'Remi\'s PHP 5.5 RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/php55/mirror',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/php55/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',

--- a/manifests/repo/remi_php56.pp
+++ b/manifests/repo/remi_php56.pp
@@ -3,9 +3,14 @@
 # This class installs the remi-php56 repo
 #
 class yum::repo::remi_php56 {
+  $releasever = $::os['name'] ? {
+    /(?i:Amazon)/ => '6',
+    default       => '$releasever',  # Yum var
+  }
+
   yum::managed_yumrepo { 'remi-php56':
     descr      => 'Remi\'s PHP 5.6 RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/php56/mirror',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/php56/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',

--- a/manifests/repo/remi_php70.pp
+++ b/manifests/repo/remi_php70.pp
@@ -3,9 +3,14 @@
 # This class installs the remi-php70 repo
 #
 class yum::repo::remi_php70 {
+  $releasever = $::os['name'] ? {
+    /(?i:Amazon)/ => '6',
+    default       => '$releasever',  # Yum var
+  }
+
   yum::managed_yumrepo { 'remi-php70':
     descr      => 'Remi\'s PHP 7.0 RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/php70/mirror',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/php70/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',

--- a/manifests/repo/remi_safe.pp
+++ b/manifests/repo/remi_safe.pp
@@ -3,9 +3,14 @@
 # This class installs the remi safe repo
 #
 class yum::repo::remi_safe {
+  $releasever = $::os['name'] ? {
+    /(?i:Amazon)/ => '6',
+    default       => '$releasever',  # Yum var
+  }
+
   yum::managed_yumrepo { 'remi-safe':
     descr      => 'Safe Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/safe/mirror',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/safe/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',

--- a/manifests/repo/remi_test.pp
+++ b/manifests/repo/remi_test.pp
@@ -3,9 +3,14 @@
 # This class installs the remi test repo
 #
 class yum::repo::remi_test {
+  $releasever = $::os['name'] ? {
+    /(?i:Amazon)/ => '6',
+    default       => '$releasever',  # Yum var
+  }
+
   yum::managed_yumrepo { 'remi-test':
     descr      => 'Remi\'s test RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => 'http://rpms.remirepo.net/enterprise/$releasever/test/mirror',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/test/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',


### PR DESCRIPTION

remi repos doesn't have a 'latest' endpoint, thus it won't work
on Amazon Linux.