### PR TITLE
Issue 175 - Switches to use the real mirror URLs as *repo.* no longer exits

### DIFF
--- a/manifests/repo/webtatic.pp
+++ b/manifests/repo/webtatic.pp
@@ -4,11 +4,7 @@
 #
 class yum::repo::webtatic {
   $osver = split($::operatingsystemrelease, '[.]')
-  $mirrorlist = $osver[0] ? {
-    '5' => 'http://repo.webtatic.com/yum/centos/5/$basearch/mirrorlist',
-    '6' => 'http://repo.webtatic.com/yum/el6/$basearch/mirrorlist',
-    '7' => 'http://repo.webtatic.com/yum/el7/$basearch/mirrorlist',
-  }
+  $mirrorlist = "https://mirror.webtatic.com/yum/el${osver[0]}/\$basearch/mirrorlist"
   $gpgkey = $osver[0] ? {
     '7'     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-webtatic-el7',
     default => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-webtatic-andy',


### PR DESCRIPTION
 * Switches to use the real mirror URLs as `*repo.*` no longer exits