### PR TITLE
service parameter "name" make no sense

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -29,7 +29,6 @@ class yum::cron {
 
   service { 'yum-cron':
     ensure     => $manage_update_service_ensure,
-    name       => $yum::service,
     enable     => $manage_update_service_enable,
     hasstatus  => true,
     hasrestart => true,


### PR DESCRIPTION

service parameter "name" make no sense, variable $yum::service variable is not defined.
WARN [puppetserver] Puppet Unknown variable: 'yum::service'. at external/yum/manifests/cron.pp:32:19

issue #181
